### PR TITLE
add metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
   ],
   "main": "index.js",
   "author": "Nathan A Sculli <scull7@gmail.com>",
+  "homepage": "https://github.com/scull7/bs-sqlite/",
+  "repository": "https://github.com/scull7/bs-sqlite/",
+  "bugs": "https://github.com/scull7/bs-sqlite/issues",
   "license": "MIT",
   "dependencies": {
     "better-sqlite3": "^4.1.0"


### PR DESCRIPTION
These are fields used by [npmjs](https://www.npmjs.com/package/bs-sqlite) and [npms](https://npms.io) to give better information about packages.

Can I ask why you haven't added this to [Redex](https://redex.github.io/)? That would be great to have this package there as well :-)